### PR TITLE
Add link to pypi history

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Major Releases of the CMIP6 Data Request.
 
 Each release is a tagged version.
+
+Releases prior to v01.00.22 can be found via [pypi](https://pypi.org/project/dreqPy/#history)


### PR DESCRIPTION
Hi @martinjuckes 

This would cover #1 ; A very minor change to the README to put a link to pypi on the front page